### PR TITLE
More lax parsing of Perl Critic output

### DIFF
--- a/lib/Code/TidyAll/Plugin/PerlCritic.pm
+++ b/lib/Code/TidyAll/Plugin/PerlCritic.pm
@@ -14,7 +14,7 @@ sub validate_file {
     my $cmd = sprintf( "%s %s %s", $self->cmd, $self->argv, $file );
     my $output;
     run3( $cmd, \undef, \$output, \$output );
-    die "$output\n" if $output !~ /^.* source OK\n/;
+    die "$output\n" if $output !~ /^.* source OK\n/s;
 }
 
 1;


### PR DESCRIPTION
Some plugins emit warnings before deciding that the output is actually okay.  Before this commit these warnings would cause Perl Critic to fail even though the output says "source OK" finally at the end.