### PR TITLE
Do not generate warnings if the file does not have Pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- The PodChecker plugin no longer generates warnings about an undef variable
+  if the file did not have any Pod.
+
+
 0.25     2015-03-31
 
 [ENHANCEMENTS]

--- a/lib/Code/TidyAll/Plugin/PodChecker.pm
+++ b/lib/Code/TidyAll/Plugin/PodChecker.pm
@@ -18,8 +18,8 @@ sub validate_file {
     open my $fh, '>', \$output;
     $checker->parse_from_file( $file, $fh );
     die $output
-        if $checker->num_errors
-        or ( $self->warnings && $checker->num_warnings );
+        if $checker->num_errors > 0
+        || ( $self->warnings && $checker->num_warnings > 0 );
 }
 
 1;


### PR DESCRIPTION
Currently the PodChecker plugin will generate the following warning if the file does not have any Pod:

```
Use of uninitialized value $output in die at /home/greg/perl5/perlbrew/perls/perl-5.20.2/lib/site_perl/5.20.2/Code/TidyAll/Plugin/PodChecker.pm line 23.
```

The reason is that Pod::Checker sets the num_errors and num_warnings to -1 if no Pod is found. Perhaps a future version of the plugin could detect this and optionally fail based on it, but the current failure and message is not useful.